### PR TITLE
Add --repo-subdir (-s) to lookup quadlets path in a repo

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -85,7 +85,7 @@ func outputQuadlet(repoURL, quadletName, downloadPath string, out io.Writer) err
 		return fmt.Errorf("failed to clone repository: %v", err)
 	}
 
-	srcPath := filepath.Join(downloadPath, quadletName)
+	srcPath := filepath.Join(downloadPath, repoSubdir, quadletName)
 	log.Debugf("showing quadlet in path %s \n", srcPath)
 
 	// Read all the entries in the source directory

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -58,7 +59,7 @@ All quadlet repos should have a directory structure where every quadlet is a top
 		}
 		log.Infof("Installing quadlet %q", quadletName)
 		log.Debug("tmp dir name " + tmpDir)
-		err = downloadDirectory(repoURL, quadletName, tmpDir)
+		err = downloadDirectory(repoURL, repoSubdir, quadletName, tmpDir)
 		if err != nil {
 			return err
 		}
@@ -116,7 +117,7 @@ func init() {
 
 }
 
-func downloadDirectory(repoURL, quadletName, downloadPath string) error {
+func downloadDirectory(repoURL, repoPath, quadletName, downloadPath string) error {
 	log.Debug("cloning repo")
 	// Clone the repository
 	_, err := git.PlainClone(downloadPath, false, &git.CloneOptions{
@@ -127,6 +128,7 @@ func downloadDirectory(repoURL, quadletName, downloadPath string) error {
 		return fmt.Errorf("failed to clone repository: %v", err)
 	}
 
+	downloadPath = path.Join(downloadPath, repoPath)
 	if dryRun {
 		noSystemdDaemonReload = true
 		log.Debug("Install Dry Run")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -58,6 +59,8 @@ var listCmd = &cobra.Command{
 			return fmt.Errorf("failed to clone repository: %v", err)
 		}
 
+		workDir = path.Join(workDir, repoSubdir)
+		log.Debug("walk dir -------------- " + workDir)
 		filepath.Walk(workDir, func(path string, info fs.FileInfo, err error) error {
 			if info.IsDir() {
 				rel, err := filepath.Rel(workDir, path)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	cfgFile string
-	verbose bool
+	cfgFile    string
+	verbose    bool
+	repoSubdir string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -61,6 +62,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.pq.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().StringVarP(&repoSubdir, "repo-subdir", "s", "", "verbose output")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.


### PR DESCRIPTION
For repositories that hold their quadlet directories under internal path
and not the default root, pass --repo-subdir

For this repo structure:

| https://my-repo
|   my-quadlets\
|       forgejo\
            forgejo.container

Use:
  pq inspect --repo https://my-repo --repo-subdir my-quadlets forgejo

Fixes: #25
Signed-off-by: Roy Golan <rgolan@redhat.com>
