### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rgolangh/pq/security/code-scanning/1](https://github.com/rgolangh/pq/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow YAML file. Since the workflow primarily involves reading repository contents and building code, the least privilege required is `contents: read`. This ensures the `GITHUB_TOKEN` is limited to only read operations and avoids any unnecessary write access.

The `permissions` block should be added at the root level of the workflow (directly under `name`), so it applies to all jobs unless overridden at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
